### PR TITLE
Update 拓扑斯 and topos.md

### DIFF
--- a/拓扑斯 and topos.md
+++ b/拓扑斯 and topos.md
@@ -41,3 +41,44 @@
 
 总的来说，拓扑斯是范畴论中的一种结构，广泛应用于数学的多个领域，如代数几何和逻辑
 ```
+
+```htmnl
+Citations
+Faviconzh.wikipedia.org
+拓撲斯- 維基百科，自由的百科全書
+February 5, 2011 — 數學中，拓撲斯（topos）是一種範疇，性狀類似拓撲空間上的集合層範疇。 目次. 1 格羅滕迪克拓撲斯（幾何中的拓子）. 1.1 等價構造. 1.1.1 Giraud公理; 1.1.2 例子.
+Faviconblog.csdn.net
+拓扑斯理论（Topos Theory） 原创 - CSDN博客
+拓扑斯理论（Topos Theory）是数学逻辑的一个分支，起源于对集合论和拓扑学概念的概括和推广。它由亚历山大·格罗滕迪克（Alexander Grothendieck）在20世纪60年代引入，后来 ...
+More
+home.ustc.edu.cn
+[PDF] Stochastic Process
+June 21, 2024 — ... 斯公式翻转一下： q(x, y) = P(Ym+1 = y|Ym = x). = P(Xn−m−1 = y|Xn−m = x). = P(Xn−m = x|Xn−m−1 = y)P(Xn−m−1 = y). P(Xn−m = x). = µ(y)p(y ...
+Faviconm.douban.com
+拓扑斯理论- Topos Theory - 豆瓣
+October 29, 2022 — 在数学中，拓扑斯是一种范畴论，其行为类似于拓扑空间(或者更一般地说:在一个站点（site）上)上的集合束的范畴。拓扑斯的行为很像集合范畴，并且拥有局部化 ...
+Faviconcnblogs.com
+图论I - qAlex_Weiq - 博客园
+May 25, 2022 — 最短路计数相当于DAG 路径计数，拓扑排序后DP。最短路DAG 的任意一棵生成树均为最短路树。最短路树计数相当于DAG 生成树计数，使用矩阵树定理 ...
+Faviconicourse.club
+[PDF] USTC基础数学修课指南
+September 25, 2020 — 本指南下一次的改版的内容扩充可能会集中于几何与拓扑方向。例如微分流形中的拓展知. 识(Chern-Weil理论、李群与纤维丛等)，少量与几何分析有关 ...
+Faviconzhihu.com
+能否通俗地介绍一下拓扑斯(topos) 这个概念？ - 知乎
+September 28, 2015 — 所以作为数学术语，topos一词源自topology，拓扑斯是一种强调拓扑特性的空间。 ... 拓扑斯理论有两条不独立的发展脉络，可以概括为几何（以 ...
+Faviconzh.wikipedia.org
+拓撲斯- 維基百科，自由的百科全書
+數學中，拓撲斯（topos）是一種範疇，性狀類似拓撲空間上的集合層範疇。 目次. 1 格羅滕迪克拓撲斯（幾何中的拓子）. 1.1 等價構造. 1.1.1 Giraud公理; 1.1.2 例子.
+Faviconzh.wikipedia.org
+拓扑斯- 维基百科，自由的百科全书
+数学中，拓扑斯（topos）是一种范畴，性状类似拓扑空间上的集合层范畴。 目录. 1 格罗滕迪克拓扑斯（几何中的拓子）. 1.1 等价构造. 1.1.1 Giraud公理; 1.1.2 例子.
+Faviconhmong.fandom.com
+浅谈初等拓扑斯理论| 创象Wiki - Fandom
+拓扑斯（topos）理论是当代数学的基础性领域，可以视为范畴论深化发展。一般所谈的拓扑斯，可能有两种解释，一种是Grothendieck拓扑斯，另一种是初等拓扑斯。
+Faviconblog.csdn.net
+拓扑斯理论（Topos Theory） 原创 - CSDN博客
+拓扑斯理论（Topos Theory）是数学逻辑的一个分支，起源于对集合论和拓扑学概念的概括和推广。它由亚历山大·格罗滕迪克（Alexander Grothendieck）在20世纪60年代引入，后来 ...
+pdcnet.org
+從它的涵蓋性、采統性以及應用性來看
+topo一logy (拓撲學) ,. 106. tribo-logy (磨損學) ,. Page 8. 102 臺大哲學 ... 斯和尤阿斯拉. 士師徒兩人的說辭(
+```


### PR DESCRIPTION
```markdown
# 拓扑斯 and topos

```markdown
拓扑斯（Topos）是数学中的一个概念，源自范畴论，行为类似于拓扑空间上的集合层范畴。 citeturn0search0它在代数几何和逻辑学中有重要应用。

在代数几何中，格罗滕迪克引入了拓扑斯的概念，用于研究拓扑空间上的层。 citeturn0search0拓扑斯提供了一个框架，使得即使在没有传统拓扑空间的情况下，也能形式化地应用拓扑直觉。

在逻辑学中，拓扑斯理论提供了一个统一的逻辑框架，可以处理经典逻辑和非经典逻辑。 citeturn0search3在这个框架中，逻辑命题被解释为拓扑斯中的子对象，而逻辑推理则对应于态射之间的合成。

总的来说，拓扑斯是范畴论中的一种结构，广泛应用于数学的多个领域，如代数几何和逻辑学。

拓扑斯（Topos）是数学中的一个概念，源自范畴论，行为类似于拓扑空间上的集合层范畴。 citeturn0search0它在代数几何和逻辑学中有重要应用。

在代数几何中，格罗滕迪克引入了拓扑斯的概念，用于研究拓扑空间上的层。 citeturn0search0拓扑斯提供了一个框架，使得即使在没有传统拓扑空间的情况下，也能形式化地应用拓扑直觉。

在逻辑学中，拓扑斯理论提供了一个统一的逻辑框架，可以处理经典逻辑和非经典逻辑。 citeturn0search3在这个框架中，逻辑命题被解释为拓扑斯中的子对象，而逻辑推理则对应于态射之间的合成。

总的来说，拓扑斯是范畴论中的一种结构，广泛应用于数学的多个领域，如代数几何和逻辑学。

拓扑斯（Topos）是数学中的一个概念，源自范畴论，行为类似于拓扑空间上的集合层范畴。 citeturn0search0它在代数几何和逻辑学中有重要应用。

在代数几何中，格罗滕迪克引入了拓扑斯的概念，用于研究拓扑空间上的层。 citeturn0search0拓扑斯提供了一个框架，使得即使在没有传统拓扑空间的情况下，也能形式化地应用拓扑直觉。

在逻辑学中，拓扑斯理论提供了一个统一的逻辑框架，可以处理经典逻辑和非经典逻辑。 citeturn0search3在这个框架中，逻辑命题被解释为拓扑斯中的子对象，而逻辑推理则对应于态射之间的合成。

总的来说，拓扑斯是范畴论中的一种结构，广泛应用于数学的多个领域，如代数几何和逻辑学。

拓扑斯（Topos）是数学中的一个概念，源自范畴论，行为类似于拓扑空间上的集合层范畴。 citeturn0search0它在代数几何和逻辑学中有重要应用。

在代数几何中，格罗滕迪克引入了拓扑斯的概念，用于研究拓扑空间上的层。 citeturn0search0拓扑斯提供了一个框架，使得即使在没有传统拓扑空间的情况下，也能形式化地应用拓扑直觉。

在逻辑学中，拓扑斯理论提供了一个统一的逻辑框架，可以处理经典逻辑和非经典逻辑。 citeturn0search3在这个框架中，逻辑命题被解释为拓扑斯中的子对象，而逻辑推理则对应于态射之间的合成。

总的来说，拓扑斯是范畴论中的一种结构，广泛应用于数学的多个领域，如代数几何和逻辑学。

拓扑斯（Topos）是数学中的一个概念，源自范畴论，行为类似于拓扑空间上的集合层范畴。 citeturn0search0它在代数几何和逻辑学中有重要应用。

在代数几何中，格罗滕迪克引入了拓扑斯的概念，用于研究拓扑空间上的层。 citeturn0search0拓扑斯提供了一个框架，使得即使在没有传统拓扑空间的情况下，也能形式化地应用拓扑直觉。

在逻辑学中，拓扑斯理论提供了一个统一的逻辑框架，可以处理经典逻辑和非经典逻辑。 citeturn0search3在这个框架中，逻辑命题被解释为拓扑斯中的子对象，而逻辑推理则对应于态射之间的合成。

总的来说，拓扑斯是范畴论中的一种结构，广泛应用于数学的多个领域，如代数几何和逻辑
```

```htmnl
Citations
Faviconzh.wikipedia.org
拓撲斯- 維基百科，自由的百科全書
February 5, 2011 — 數學中，拓撲斯（topos）是一種範疇，性狀類似拓撲空間上的集合層範疇。 目次. 1 格羅滕迪克拓撲斯（幾何中的拓子）. 1.1 等價構造. 1.1.1 Giraud公理; 1.1.2 例子. Faviconblog.csdn.net
拓扑斯理论（Topos Theory） 原创 - CSDN博客
拓扑斯理论（Topos Theory）是数学逻辑的一个分支，起源于对集合论和拓扑学概念的概括和推广。它由亚历山大·格罗滕迪克（Alexander Grothendieck）在20世纪60年代引入，后来 ... More
home.ustc.edu.cn
[PDF] Stochastic Process
June 21, 2024 — ... 斯公式翻转一下： q(x, y) = P(Ym+1 = y|Ym = x). = P(Xn−m−1 = y|Xn−m = x). = P(Xn−m = x|Xn−m−1 = y)P(Xn−m−1 = y). P(Xn−m = x). = µ(y)p(y ... Faviconm.douban.com
拓扑斯理论- Topos Theory - 豆瓣
October 29, 2022 — 在数学中，拓扑斯是一种范畴论，其行为类似于拓扑空间(或者更一般地说:在一个站点（site）上)上的集合束的范畴。拓扑斯的行为很像集合范畴，并且拥有局部化 ... Faviconcnblogs.com
图论I - qAlex_Weiq - 博客园
May 25, 2022 — 最短路计数相当于DAG 路径计数，拓扑排序后DP。最短路DAG 的任意一棵生成树均为最短路树。最短路树计数相当于DAG 生成树计数，使用矩阵树定理 ... Faviconicourse.club
[PDF] USTC基础数学修课指南
September 25, 2020 — 本指南下一次的改版的内容扩充可能会集中于几何与拓扑方向。例如微分流形中的拓展知. 识(Chern-Weil理论、李群与纤维丛等)，少量与几何分析有关 ... Faviconzhihu.com
能否通俗地介绍一下拓扑斯(topos) 这个概念？ - 知乎
September 28, 2015 — 所以作为数学术语，topos一词源自topology，拓扑斯是一种强调拓扑特性的空间。 ... 拓扑斯理论有两条不独立的发展脉络，可以概括为几何（以 ... Faviconzh.wikipedia.org
拓撲斯- 維基百科，自由的百科全書
數學中，拓撲斯（topos）是一種範疇，性狀類似拓撲空間上的集合層範疇。 目次. 1 格羅滕迪克拓撲斯（幾何中的拓子）. 1.1 等價構造. 1.1.1 Giraud公理; 1.1.2 例子. Faviconzh.wikipedia.org
拓扑斯- 维基百科，自由的百科全书
数学中，拓扑斯（topos）是一种范畴，性状类似拓扑空间上的集合层范畴。 目录. 1 格罗滕迪克拓扑斯（几何中的拓子）. 1.1 等价构造. 1.1.1 Giraud公理; 1.1.2 例子. Faviconhmong.fandom.com
浅谈初等拓扑斯理论| 创象Wiki - Fandom
拓扑斯（topos）理论是当代数学的基础性领域，可以视为范畴论深化发展。一般所谈的拓扑斯，可能有两种解释，一种是Grothendieck拓扑斯，另一种是初等拓扑斯。 Faviconblog.csdn.net
拓扑斯理论（Topos Theory） 原创 - CSDN博客
拓扑斯理论（Topos Theory）是数学逻辑的一个分支，起源于对集合论和拓扑学概念的概括和推广。它由亚历山大·格罗滕迪克（Alexander Grothendieck）在20世纪60年代引入，后来 ... pdcnet.org
從它的涵蓋性、采統性以及應用性來看
topo一logy (拓撲學) ,. 106. tribo-logy (磨損學) ,. Page 8. 102 臺大哲學 ... 斯和尤阿斯拉. 士師徒兩人的說辭(
```
```