### PR TITLE
Update .md

### DIFF
--- a/.md
+++ b/.md
@@ -1,1 +1,55 @@
 # f:R^m -> R^n?
+
+## is it z^n -> r^m?
+
+OpenAI:
+Yes, the **Skip-gram model with Negative Sampling** can be understood as a **function transformation** in mathematical terms. Specifically, it maps a **discrete space** (words as indices) to a **continuous vector space** (word embeddings). 
+
+### **Mathematical Mapping**
+If we define:
+- **Vocabulary space**: A set of words represented by their indices in \( \mathbb{Z}^n \) (discrete space).
+- **Embedding space**: A lower-dimensional continuous space \( \mathbb{R}^m \) (vector space of real numbers).
+
+Then, the Skip-gram model performs the transformation:
+
+\[
+f: \mathbb{Z}^n \to \mathbb{R}^m
+\]
+
+where:
+- **\( \mathbb{Z}^n \)**: Words are represented as **one-hot encoded vectors** (discrete space).
+- **\( \mathbb{R}^m \)**: The model maps these to a **dense m-dimensional word embedding**.
+
+#### **Example**
+- Suppose we have **6 words** in the vocabulary (\( n = 6 \)) and each word is mapped to a **100-dimensional vector** (\( m = 100 \)).
+- The mapping looks like:
+
+  \[
+  \text{"sat"} \mapsto (-0.12, 0.34, ..., 0.88) \in \mathbb{R}^{100}
+  \]
+
+Thus, **instead of keeping words as discrete symbols**, Skip-gram learns a mapping into **a continuous vector space**, capturing relationships between words.
+
+---
+
+### **Does Negative Sampling Change This Mapping?**
+No, **Negative Sampling** does not change the overall function type. It only modifies how the model is trained by:
+- **Replacing full softmax** with a simpler objective function.
+- **Using sampled negative examples** to update the embeddings more efficiently.
+
+So, the mapping remains:
+
+\[
+f: \mathbb{Z}^n \to \mathbb{R}^m
+\]
+
+where the learned word vectors in \( \mathbb{R}^m \) are adjusted based on **both positive (true context) and negative (randomly sampled) words**.
+
+---
+
+### **💡 Conclusion**
+✅ Skip-gram **maps discrete words** (indices in \( \mathbb{Z}^n \)) to **dense word vectors** in \( \mathbb{R}^m \).  
+✅ **Negative Sampling speeds up training** but does not change the fundamental mapping.  
+✅ The **word embeddings capture semantic relationships** between words in the continuous space \( \mathbb{R}^m \).  
+
+Would you like an example where we visualize embeddings in 2D or compute distances between words? 🚀


### PR DESCRIPTION
# f:R^m -> R^n?

## is it z^n -> r^m?

OpenAI:
Yes, the **Skip-gram model with Negative Sampling** can be understood as a **function transformation** in mathematical terms. Specifically, it maps a **discrete space** (words as indices) to a **continuous vector space** (word embeddings). 

### **Mathematical Mapping**
If we define:
- **Vocabulary space**: A set of words represented by their indices in \( \mathbb{Z}^n \) (discrete space).
- **Embedding space**: A lower-dimensional continuous space \( \mathbb{R}^m \) (vector space of real numbers).

Then, the Skip-gram model performs the transformation:

\[
f: \mathbb{Z}^n \to \mathbb{R}^m
\]

where:
- **\( \mathbb{Z}^n \)**: Words are represented as **one-hot encoded vectors** (discrete space).
- **\( \mathbb{R}^m \)**: The model maps these to a **dense m-dimensional word embedding**.

#### **Example**
- Suppose we have **6 words** in the vocabulary (\( n = 6 \)) and each word is mapped to a **100-dimensional vector** (\( m = 100 \)).
- The mapping looks like:

  \[ \text{"sat"} \mapsto (-0.12, 0.34, ..., 0.88) \in \mathbb{R}^{100} \]

Thus, **instead of keeping words as discrete symbols**, Skip-gram learns a mapping into **a continuous vector space**, capturing relationships between words.

---

### **Does Negative Sampling Change This Mapping?** No, **Negative Sampling** does not change the overall function type. It only modifies how the model is trained by:
- **Replacing full softmax** with a simpler objective function.
- **Using sampled negative examples** to update the embeddings more efficiently.

So, the mapping remains:

\[
f: \mathbb{Z}^n \to \mathbb{R}^m
\]

where the learned word vectors in \( \mathbb{R}^m \) are adjusted based on **both positive (true context) and negative (randomly sampled) words**.

---

### **💡 Conclusion**
✅ Skip-gram **maps discrete words** (indices in \( \mathbb{Z}^n \)) to **dense word vectors** in \( \mathbb{R}^m \).   ✅ **Negative Sampling speeds up training** but does not change the fundamental mapping.   ✅ The **word embeddings capture semantic relationships** between words in the continuous space \( \mathbb{R}^m \).  

Would you like an example where we visualize embeddings in 2D or compute distances between words? 🚀